### PR TITLE
Update probabilistic_scoring_list.py

### DIFF
--- a/skpsl/estimators/probabilistic_scoring_list.py
+++ b/skpsl/estimators/probabilistic_scoring_list.py
@@ -98,7 +98,7 @@ class _ClassifierAtK(BaseEstimator, ClassifierMixin):
             raise NotFittedError()
         if not self.features:
             p_pos = self.calibrator.transform([[0]])
-            return entropy([p_pos, 1 - p_pos])[0]
+            return entropy([p_pos, 1 - p_pos]).item()
         total_scores = self._compute_total_scores(X, self.features, self.scores_vec, self.thresholds)
         return self._expected_entropy(total_scores, calibrator=self.calibrator)
 

--- a/skpsl/estimators/probabilistic_scoring_list.py
+++ b/skpsl/estimators/probabilistic_scoring_list.py
@@ -98,7 +98,7 @@ class _ClassifierAtK(BaseEstimator, ClassifierMixin):
             raise NotFittedError()
         if not self.features:
             p_pos = self.calibrator.transform([[0]])
-            return entropy([p_pos, 1 - p_pos])
+            return entropy([p_pos, 1 - p_pos])[0]
         total_scores = self._compute_total_scores(X, self.features, self.scores_vec, self.thresholds)
         return self._expected_entropy(total_scores, calibrator=self.calibrator)
 


### PR DESCRIPTION
Fix a small bug which leads to returning a single-valued array instead of a scalar for the score of the default ClassifiedAtK without features and scores.